### PR TITLE
Selenium test fixes

### DIFF
--- a/.github/workflows/web-external-api.yml
+++ b/.github/workflows/web-external-api.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   external-api:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v1
       with:

--- a/selenium_tests/gnps_pages/test_library_page.py
+++ b/selenium_tests/gnps_pages/test_library_page.py
@@ -8,6 +8,7 @@ from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.chrome.options import Options
 import unittest, time, re
 import os
 
@@ -16,9 +17,9 @@ warnings.filterwarnings('ignore')
 
 class TestInterfaceready(unittest.TestCase):
     def setUp(self):
-        profile = webdriver.FirefoxProfile()
-        profile.accept_untrusted_certs = True
-        self.driver = webdriver.Firefox(firefox_profile=profile)
+        options = Options()
+        options.headless = True
+        self.driver = webdriver.Chrome(options=options)
         self.driver.implicitly_wait(15)
         self.base_url = os.environ.get("SERVER_URL", "https://gnps.ucsd.edu")
         self.vars = {}
@@ -32,14 +33,14 @@ class TestInterfaceready(unittest.TestCase):
         
         time.sleep(15)
         
-        elements = self.driver.find_element_by_id("other_library_spectra.library_membership_input")
+        elements = self.driver.find_element(by=By.ID, value="other_library_spectra.library_membership_input")
 
     def test_library_page_table2(self):
         self.driver.get("{}/ProteoSAFe/gnpslibrary.jsp?library=GNPS-LIBRARY&test=true".format(self.base_url))
         
         time.sleep(15)
         
-        elements = self.driver.find_element_by_id("main.spectrum_id_input")
+        elements = self.driver.find_element(by=By.ID, value="main.spectrum_id_input")
 
         
 

--- a/selenium_tests/input_form/test_login_logout.py
+++ b/selenium_tests/input_form/test_login_logout.py
@@ -6,6 +6,7 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import Select
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.chrome.options import Options
 import unittest, time, re
 
 import warnings
@@ -13,7 +14,9 @@ warnings.filterwarnings('ignore')
 
 class Proteomics2LoginLogout(unittest.TestCase):
     def setUp(self):
-        self.driver = webdriver.PhantomJS(service_args=['--ignore-ssl-errors=true'])
+        options = Options()
+        options.headless = True
+        self.driver = webdriver.Chrome(options=options)
         self.driver.implicitly_wait(30)
         self.base_url = os.environ.get("SERVER_URL", "https://gnps.ucsd.edu/")
         print("Testing", self.base_url)

--- a/selenium_tests/input_form/test_login_logout.py
+++ b/selenium_tests/input_form/test_login_logout.py
@@ -32,20 +32,22 @@ class Proteomics2LoginLogout(unittest.TestCase):
             except: pass
             time.sleep(1)
         else: self.fail("time out")
-        driver.find_element_by_name("user").clear()
-        driver.find_element_by_name("user").send_keys("test")
-        driver.find_element_by_name("password").clear()
-        driver.find_element_by_name("password").send_keys(os.environ.get("CCMS_TESTUSER_PASSWORD"))
-        driver.find_element_by_name("login").click()
+        username_field = driver.find_element(by=By.NAME, value="user")
+        username_field.clear()
+        username_field.send_keys("test")
+        password_field = driver.find_element(by=By.NAME, value="password")
+        password_field.clear()
+        password_field.send_keys(os.environ.get("CCMS_TESTUSER_PASSWORD"))
+        driver.find_element(by=By.NAME, value="login").click()
         for i in range(60):
             try:
-                if "Successful login" == driver.find_element_by_xpath("//h1").text: break
+                if "Successful login" == driver.find_element(by=By.XPATH, value="//h1").text: break
             except: pass
             time.sleep(1)
         else: self.fail("time out")
         for i in range(60):
             try:
-                if "Logout" == driver.find_element_by_xpath("//a[@href=\"/ProteoSAFe/user/logout.jsp\"]").text: break
+                if "Logout" == driver.find_element(by=By.XPATH, value="//a[@href=\"/ProteoSAFe/user/logout.jsp\"]").text: break
             except: pass
             time.sleep(1)
         else: self.fail("time out")
@@ -53,10 +55,10 @@ class Proteomics2LoginLogout(unittest.TestCase):
         # Logout is not working, exiting before we do it
         return 0
 
-        driver.find_element_by_link_text("Logout").click()
+        driver.find_element(by=By.LINK_TEXT, value="Logout").click()
         for i in range(60):
             try:
-                if "Successful logout" == driver.find_element_by_xpath("//h1").text: break
+                if "Successful logout" == driver.find_element(by=By.XPATH, value="//h1").text: break
             except: pass
             time.sleep(1)
         else: self.fail("time out")

--- a/selenium_tests/input_form/test_override_cloned_task_workflow_version.py
+++ b/selenium_tests/input_form/test_override_cloned_task_workflow_version.py
@@ -5,6 +5,7 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import Select
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.chrome.options import Options
 import unittest, time, re
 import os
 
@@ -13,7 +14,9 @@ warnings.filterwarnings('ignore')
 
 class OverrideClonedTaskWorkflowVersion(unittest.TestCase):
     def setUp(self):
-        self.driver = webdriver.PhantomJS(service_args=['--ignore-ssl-errors=true'])
+        options = Options()
+        options.headless = True
+        self.driver = webdriver.Chrome(options=options)
         self.driver.implicitly_wait(30)
         self.base_url = os.environ.get("SERVER_URL", "https://gnps.ucsd.edu")
         self.verificationErrors = []
@@ -30,14 +33,16 @@ class OverrideClonedTaskWorkflowVersion(unittest.TestCase):
             except: pass
             time.sleep(1)
         else: self.fail("time out")
-        driver.find_element_by_name("user").clear()
-        driver.find_element_by_name("user").send_keys("test")
-        driver.find_element_by_name("password").clear()
-        driver.find_element_by_name("password").send_keys(os.environ.get("CCMS_TESTUSER_PASSWORD"))
-        driver.find_element_by_name("login").click()
+        username_field = driver.find_element(by=By.NAME, value="user")
+        username_field.clear()
+        username_field.send_keys("test")
+        password_field = driver.find_element(by=By.NAME, value="password")
+        password_field.clear()
+        password_field.send_keys(os.environ.get("CCMS_TESTUSER_PASSWORD"))
+        driver.find_element(by=By.NAME, value="login").click()
         for i in range(60):
             try:
-                if "Successful login" == driver.find_element_by_xpath("//h1").text: break
+                if "Successful login" == driver.find_element(by=By.XPATH, value="//h1").text: break
             except: pass
             time.sleep(1)
         else: self.fail("time out")
@@ -49,7 +54,7 @@ class OverrideClonedTaskWorkflowVersion(unittest.TestCase):
         time.sleep(2)
 
         # Assuming there is only one small tag in the page, this could be violated later
-        small_tags = driver.find_element_by_tag_name("small")
+        small_tags = driver.find_element(by=By.TAG_NAME, value="small")
         version_text = small_tags.text
         version = version_text.replace("Version ", "")
         self.assertEqual(version, "release_14")
@@ -62,7 +67,7 @@ class OverrideClonedTaskWorkflowVersion(unittest.TestCase):
         time.sleep(2)
 
         # Assuming there is only one small tag in the page, this could be violated later
-        small_tags = driver.find_element_by_tag_name("small")
+        small_tags = driver.find_element(by=By.TAG_NAME, value="small")
         version_text = small_tags.text
         version = version_text.replace("Version ", "")
         self.assertEqual(version, "release_17")
@@ -74,7 +79,7 @@ class OverrideClonedTaskWorkflowVersion(unittest.TestCase):
         time.sleep(2)
 
         # Assuming there is only one small tag in the page, this could be violated later
-        small_tags = driver.find_element_by_tag_name("small")
+        small_tags = driver.find_element(by=By.TAG_NAME, value="small")
         version_text = small_tags.text
         version = version_text.replace("Version ", "")
         self.assertNotEqual(version, "release_14")

--- a/selenium_tests/proteomics_result_views/test_result_table.py
+++ b/selenium_tests/proteomics_result_views/test_result_table.py
@@ -8,6 +8,7 @@ from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.chrome.options import Options
 import unittest, time, re
 import os
 
@@ -16,7 +17,9 @@ warnings.filterwarnings('ignore')
 
 class TestInterfaceready(unittest.TestCase):
     def setUp(self):
-        self.driver = webdriver.PhantomJS(service_args=['--ignore-ssl-errors=true'])
+        options = Options()
+        options.headless = True
+        self.driver = webdriver.Chrome(options=options)
         self.driver.implicitly_wait(1)
         self.base_url = os.environ.get("SERVER_URL", "https://proteomics3.ucsd.edu")
         self.vars = {}
@@ -32,12 +35,12 @@ class TestInterfaceready(unittest.TestCase):
         
         time.sleep(5)
 
-        # Postiive control, making sure this does exist
-        elements = self.driver.find_element_by_id("main.Found_PSMs_lowerinput")
+        # Positive control, making sure this does exist
+        elements = self.driver.find_element(by=By.ID, value="main.Found_PSMs_lowerinput")
         
-        # Checking that this doesnt exists
+        # Checking that this doesn't exist
         with self.assertRaises(NoSuchElementException):
-            elements = self.driver.find_element_by_id("main.Invalid_PSM_rows_lowerinput")
+            elements = self.driver.find_element(by=By.ID, value="main.Invalid_PSM_rows_lowerinput")
 
 
     # This makes sure on server side tables, the autohiding works
@@ -50,7 +53,7 @@ class TestInterfaceready(unittest.TestCase):
         
         # Checking that this doesnt exist
         with self.assertRaises(NoSuchElementException):
-            elements = self.driver.find_element_by_id("main_search_engine_input")
+            elements = self.driver.find_element(by=By.ID, value="main_search_engine_input")
 
     # This makes sure we don't autohide when sorting
     def test_server_sort_autohide(self):
@@ -69,7 +72,7 @@ class TestInterfaceready(unittest.TestCase):
             print("----------")
         
         # Checking that this does exist
-        elements = self.driver.find_element_by_id("view_differential__dyn_#adj.pvalue_asc")
+        elements = self.driver.find_element(by=By.ID, value="view_differential__dyn_#adj.pvalue_asc")
 
 if __name__ == "__main__":
     unittest.main()

--- a/selenium_tests/result_views/test_gnps_results_pages.py
+++ b/selenium_tests/result_views/test_gnps_results_pages.py
@@ -8,6 +8,7 @@ from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.chrome.options import Options
 import unittest, time, re
 
 import warnings
@@ -15,7 +16,9 @@ warnings.filterwarnings('ignore')
 
 class TestInterfaceready(unittest.TestCase):
     def setUp(self):
-        self.driver = webdriver.PhantomJS(service_args=['--ignore-ssl-errors=true'])
+        options = Options()
+        options.headless = True
+        self.driver = webdriver.Chrome(options=options)
         self.driver.implicitly_wait(1)
         self.vars = {}
         self.base_url = os.environ.get("SERVER_URL", "https://gnps.ucsd.edu")
@@ -34,7 +37,7 @@ class TestInterfaceready(unittest.TestCase):
             print(entry)
         
         # Checking that this does exist
-        elements = self.driver.find_element_by_id("main.CLUSTERID1_lowerinput")
+        elements = self.driver.find_element(by=By.ID, value="main.CLUSTERID1_lowerinput")
 
     def test_gnps_networking(self):
         url = "{}/ProteoSAFe/result.jsp?task=92b9d140de144bb1afc0f0775858d453&view=view_raw_spectra&test=true".format(self.base_url)
@@ -44,10 +47,7 @@ class TestInterfaceready(unittest.TestCase):
         time.sleep(30)
         
         # Checking that this does exist
-        elements = self.driver.find_element_by_id("main.AllFiles_input")
-
-    
-
+        elements = self.driver.find_element(by=By.ID, value="main.AllFiles_input")
 
 if __name__ == "__main__":
     unittest.main()

--- a/selenium_tests/result_views/test_network_displayer_count_nodes_edges.py
+++ b/selenium_tests/result_views/test_network_displayer_count_nodes_edges.py
@@ -8,6 +8,7 @@ from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.chrome.options import Options
 import unittest, time, re
 
 import warnings
@@ -15,7 +16,9 @@ warnings.filterwarnings('ignore')
 
 class TestInterfaceready(unittest.TestCase):
     def setUp(self):
-        self.driver = webdriver.PhantomJS(service_args=['--ignore-ssl-errors=true'])
+        options = Options()
+        options.headless = True
+        self.driver = webdriver.Chrome(options=options)
         self.driver.implicitly_wait(30)
         self.vars = {}
         self.base_url = os.environ.get("SERVER_URL", "https://gnps.ucsd.edu")
@@ -38,7 +41,6 @@ class TestInterfaceready(unittest.TestCase):
         assert len(nodes) == 0
         edges = self.driver.execute_script("return pairs_data;")
         assert len(edges) == 0
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/selenium_tests/result_views/test_network_displayer_interface_ready.py
+++ b/selenium_tests/result_views/test_network_displayer_interface_ready.py
@@ -8,6 +8,7 @@ from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.chrome.options import Options
 import unittest, time, re
 
 import warnings
@@ -15,7 +16,9 @@ warnings.filterwarnings('ignore')
 
 class TestInterfaceready(unittest.TestCase):
     def setUp(self):
-        self.driver = webdriver.PhantomJS(service_args=['--ignore-ssl-errors=true'])
+        options = Options()
+        options.headless = True
+        self.driver = webdriver.Chrome(options=options)
         self.driver.implicitly_wait(30)
         self.vars = {}
         self.base_url = os.environ.get("SERVER_URL", "https://gnps.ucsd.edu")
@@ -28,7 +31,6 @@ class TestInterfaceready(unittest.TestCase):
         WebDriverWait(self.driver, 30).until(expected_conditions.visibility_of_element_located((By.CSS_SELECTOR, ".fa-check-circle")))
         elements = self.driver.find_elements(By.CSS_SELECTOR, ".fa-check-circle")
         assert len(elements) > 0
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/selenium_tests/user_views/test_task_list.py
+++ b/selenium_tests/user_views/test_task_list.py
@@ -27,6 +27,7 @@ class TestTaskList(unittest.TestCase):
         driver = self.driver
         # log in as test user
         print("Logging in as test user.")
+        print("URL = {}/ProteoSAFe/user/login.jsp?test=true".format(self.base_url))
         driver.get("{}/ProteoSAFe/user/login.jsp?test=true".format(self.base_url))
         for i in range(60):
             try:

--- a/selenium_tests/user_views/test_task_list.py
+++ b/selenium_tests/user_views/test_task_list.py
@@ -18,7 +18,7 @@ class TestTaskList(unittest.TestCase):
         options.headless = True
         self.driver = webdriver.Chrome(options=options)
         self.driver.implicitly_wait(30)
-        self.base_url = os.environ.get("SERVER_URL")
+        self.base_url = os.environ.get("SERVER_URL", "https://gnps.ucsd.edu")
         self.verificationErrors = []
         self.accept_next_alert = True
 

--- a/selenium_tests/user_views/test_task_list.py
+++ b/selenium_tests/user_views/test_task_list.py
@@ -18,7 +18,7 @@ class TestTaskList(unittest.TestCase):
         options.headless = True
         self.driver = webdriver.Chrome(options=options)
         self.driver.implicitly_wait(30)
-        self.base_url = os.environ.get("SERVER_URL", "https://gnps.ucsd.edu")
+        self.base_url = os.environ.get("SERVER_URL", "https://gnps.ucsd.edu/")
         self.verificationErrors = []
         self.accept_next_alert = True
 

--- a/selenium_tests/user_views/test_task_list.py
+++ b/selenium_tests/user_views/test_task_list.py
@@ -19,6 +19,7 @@ class TestTaskList(unittest.TestCase):
         self.driver = webdriver.Chrome(options=options)
         self.driver.implicitly_wait(30)
         self.base_url = os.environ.get("SERVER_URL", "https://gnps.ucsd.edu/")
+        print("Testing", self.base_url)
         self.verificationErrors = []
         self.accept_next_alert = True
 

--- a/selenium_tests/user_views/test_task_list.py
+++ b/selenium_tests/user_views/test_task_list.py
@@ -5,6 +5,7 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import Select
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.chrome.options import Options
 import unittest, time, re
 import os
 
@@ -13,7 +14,9 @@ warnings.filterwarnings('ignore')
 
 class TestTaskList(unittest.TestCase):
     def setUp(self):
-        self.driver = webdriver.PhantomJS(service_args=['--ignore-ssl-errors=true'])
+        options = Options()
+        options.headless = True
+        self.driver = webdriver.Chrome(options=options)
         self.driver.implicitly_wait(30)
         self.base_url = os.environ.get("SERVER_URL")
         self.verificationErrors = []
@@ -30,14 +33,16 @@ class TestTaskList(unittest.TestCase):
             except: pass
             time.sleep(1)
         else: self.fail("time out")
-        driver.find_element_by_name("user").clear()
-        driver.find_element_by_name("user").send_keys("test")
-        driver.find_element_by_name("password").clear()
-        driver.find_element_by_name("password").send_keys(os.environ.get("CCMS_TESTUSER_PASSWORD"))
-        driver.find_element_by_name("login").click()
+        username_field = driver.find_element(by=By.NAME, value="user")
+        username_field.clear()
+        username_field.send_keys("test")
+        password_field = driver.find_element(by=By.NAME, value="password")
+        password_field.clear()
+        password_field.send_keys(os.environ.get("CCMS_TESTUSER_PASSWORD"))
+        driver.find_element(by=By.NAME, value="login").click()
         for i in range(60):
             try:
-                if "Successful login" == driver.find_element_by_xpath("//h1").text: break
+                if "Successful login" == driver.find_element(by=By.XPATH, value="//h1").text: break
             except: pass
             time.sleep(1)
         else: self.fail("time out")
@@ -50,7 +55,7 @@ class TestTaskList(unittest.TestCase):
         # verify that task list navigator is present, and contains the expected text
         print("Verifying task list pagination header.")
         pattern = "^Hits [0-9]+ ~ 30 out of [0-9]+(,[0-9]{3})*$"
-        pagination_header = driver.find_element_by_xpath("//div[@id=\"main_title\"]/following-sibling::div/span").text
+        pagination_header = driver.find_element(by=By.XPATH, value="//div[@id=\"main_title\"]/following-sibling::div/span").text
         try: self.assertTrue(re.search(pattern, pagination_header) is not None)
         except AssertionError as e: self.verificationErrors.append(str(e))
 


### PR DESCRIPTION
1. Updated web driver for all Selenium tests from PhantomJS (long since deprecated) to headless Chrome. Abandoned headless Firefox due to difficulties with managing geckodriver dependencies, since headless Chrome apparently now works fine out of the box.

2. Updated all deprecated `find_element_by_*` function calls to use proper `find_element(by=By.*, ...)` syntax.

3. Updated Ubuntu version for the "web-external-api" workflow from 18.04 (browned out due to upcoming official deprecation on 4/1/23) to 22.04.

Closes #34.